### PR TITLE
removed mean of a single value

### DIFF
--- a/rnn/elman.py
+++ b/rnn/elman.py
@@ -50,7 +50,7 @@ class model(object):
 
         # cost and gradients and learning rate
         lr = T.scalar('lr')
-        nll = -T.mean(T.log(p_y_given_x_lastword)[y])
+        nll = -T.log(p_y_given_x_lastword)[y]
         gradients = T.grad( nll, self.params )
         updates = OrderedDict(( p, p-lr*g ) for p, g in zip( self.params , gradients))
         


### PR DESCRIPTION
The variable `p_y_given_x_lastword)[y]` is a scalar so there is no need to calculate the mean in order to evaluate `nll`.
